### PR TITLE
Allow deserialization of optional fields if they are omitted

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ scalacOptions ++= Seq(
 
 libraryDependencies ++= Seq(
   "io.spray" %% "spray-json" % "1.3.4",
-  "com.propensive" %% "magnolia" % "0.7.1",
+  "com.propensive" %% "magnolia" % "0.7.2-SNAPSHOT",
   "org.scalatest" %% "scalatest" % "3.0.2" % "test"
 )
 

--- a/src/main/scala/DerivedFormats.scala
+++ b/src/main/scala/DerivedFormats.scala
@@ -24,7 +24,12 @@ trait DerivedFormats { self: BasicFormats =>
             ctx.rawConstruct(Seq.empty)
           } else {
             ctx.construct { param =>
-              param.typeclass.read(obj.fields(param.label))
+              val fieldValue = if (param.isOption) {
+                obj.fields.getOrElse(param.label, JsNull)
+              } else {
+                obj.fields(param.label)
+              }
+              param.typeclass.read(fieldValue)
             }
           }
         case js =>

--- a/src/test/scala/ProductTypeFormatTests.scala
+++ b/src/test/scala/ProductTypeFormatTests.scala
@@ -74,4 +74,21 @@ class ProductTypeFormatTests
     """{"h": {"x":true}}"""
   )
 
+  case class Opt(x: Option[Int])
+  implicit val ofmt = jsonFormat[Opt]
+
+  "Optional fields with some value" should behave like checkRoundtrip(
+    Opt(Some(2)),
+    """{"x":2}"""
+  )
+
+  "Optional fields with no value (null)" should behave like checkRoundtrip(
+    Opt(None),
+    """{"x":null}"""
+  )
+
+  "Optional fields with no value (undefined)" should "deserialize" in {
+    assert("{}".parseJson.convertTo[Opt] == Opt(None))
+  }
+
 }


### PR DESCRIPTION
(requires unmerged changes to magnolia)

Fixes #5